### PR TITLE
Feature: GitHub contributions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,46 @@
+<!---
+Provide a short summary in the Title above. Examples of good PR titles:
+* "Feature: add so-and-so models"
+* "Fix: deduplicate such-and-such"
+* "Update: dbt version 0.13.0"
+-->
+
+## Description & motivation
+<!---
+Add a description of what that story's goal is, or add a link to its associated Jira ticket.
+-->
+
+## Changes to ERD
+<!---
+Based on the description above, what are the changes you're making in the warehouse layer. Add a screenshot of the ERD you're changing and add description of main changes happening (e.g. new fact table added; adding new fields, etc.)
+
+Here are the commands to generate graph:
+- dbdocs build wh_docs/kaplan.dbml
+- Follow link
+- Go to dag
+- Screenshot
+-->
+
+## Changes to DAG
+<!---
+Show us the relevant dbt models that are being introduced or changed by inserting a screen shot of the DAG section that is impacted. 
+
+Here are the commands to generate graph:
+- dbt docs generate
+- dbt docs serve
+- Go to Relationship tab
+- Screenshot
+-->
+
+## Checklist:
+<!-- 
+This is for you as a developer. Have you done all the following tasks before submitting this PR?
+
+-->
+- [ ] My pull request represents one story (logical piece of work).
+- [ ] My SQL follows the RA style guide
+- [ ] I have materialized my models appropriately.
+- [ ] I have added appropriate tests and documentation to any new models.
+- [ ] I ran the dbt package in my development environment without error.
+- [ ] I ran the dbt test suite in my development environment without error.
+- [ ] My dbt package has no residual models that are no longer used.

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -80,13 +80,14 @@ vars:
   finance_warehouse_payment_sources: []
   product_warehouse_event_sources: []
   subscriptions_warehouse_sources: []
-  dev_warehouse_git_sources: []
+  dev_warehouse_git_sources: ['github']
   product_warehouse_usage_sources: []
   crm_warehouse_nps_sources: []
 
-  stg_git_repos_id-prefix: github-
-  stg_git_repos_etl: fivetran
-  stg_git_repos_fivetran_schema: fivetran_github
+  stg_github_id-prefix: github-
+  stg_github_etl: fivetran
+  stg_git_repos_fivetran_database: ra-development
+  stg_github_fivetran_schema: fivetran_github_rittmananalytics
 
   stg_asana_projects_id-prefix: asana-
   stg_asana_projects_etl: stitch

--- a/models/integration/int_github/int_github_commit.sql
+++ b/models/integration/int_github/int_github_commit.sql
@@ -1,0 +1,30 @@
+{% if var("dev_warehouse_git_sources") %}
+
+with commit as (
+    select *
+    from {{ ref('stg_github_commit') }}
+),
+user_email as (
+    select *
+    from {{ ref('stg_github_user_email') }}
+),
+joined as (
+    select
+        commit_sha,
+        ue.user_id,
+        author_date,
+        author_email,
+        author_name,
+        committer_date,
+        committer_email,
+        committer_name,
+        message,
+        repository_id
+    from commit c
+    left join user_email ue
+        on c.author_email = ue.email
+)
+select *
+from joined
+
+{% endif %}

--- a/models/integration/int_github/int_github_contributions.sql
+++ b/models/integration/int_github/int_github_contributions.sql
@@ -1,0 +1,71 @@
+{% if var("dev_warehouse_git_sources") %}
+
+with commit as (
+    select *
+    from {{ ref('int_github_commit') }}
+),
+pull_request as (
+    select *
+    from {{ ref('int_github_pull_request') }}
+),
+pull_request_review as (
+    select *
+    from {{ ref('int_github_pull_request_review') }}
+),
+pull_request_merged as (
+    select *
+    from {{ ref('int_github_pull_request_merged') }}
+),
+release as (
+    select *
+    from {{ ref('stg_github_release') }}
+),
+renamed_unioned as (
+    select
+        'commit' as contribution_type,
+        user_id,
+        repository_id,
+        author_date as contributed_at
+    from commit
+
+union all
+
+    select
+        'pr_raised' as contribution_type,
+        user_id,
+        repository_id,
+        created_at as contributed_at
+    from pull_request
+
+union all
+
+    select
+        'pr_' || state as contribution_type,
+        user_id,
+        repository_id,
+        submitted_at as contributed_at
+    from pull_request_review
+
+union all
+
+    select
+        'pr_merged' as contribution_type,
+        user_id,
+        repository_id,
+        merged_at as contributed_at
+    from pull_request_merged
+
+union all
+
+    select
+        'release' as contribution_type,
+        user_id,
+        repository_id,
+        created_at as contributed_at
+    from release
+
+)
+select *
+from  renamed_unioned
+
+{% endif %}

--- a/models/integration/int_github/int_github_pull_request.sql
+++ b/models/integration/int_github/int_github_pull_request.sql
@@ -1,0 +1,37 @@
+{% if var("dev_warehouse_git_sources") %}
+
+with pull_request as (
+    select *
+    from {{ ref('stg_github_pull_request') }}
+),
+issue as (
+    select *
+    from {{ ref('stg_github_issue') }}
+),
+joined as (
+    select
+        pr.pull_request_id,
+        pr.base_sha,
+        pr.base_repo_id,
+        pr.base_user_id,
+        pr.head_sha,
+        pr.head_repo_id,
+        pr.head_user_id,
+        pr.issue_id,
+        pr.merge_commit_sha,
+        pr.base_label,
+        pr.base_ref,
+        pr.is_draft,
+        pr.head_label,
+        pr.head_ref,
+        i.created_at,
+        i.repository_id,
+        i.user_id
+    from pull_request pr
+    left join issue i
+        on pr.issue_id = i.issue_id
+)
+select *
+from joined
+
+{% endif %}

--- a/models/integration/int_github/int_github_pull_request_merged.sql
+++ b/models/integration/int_github/int_github_pull_request_merged.sql
@@ -1,0 +1,26 @@
+{% if var("dev_warehouse_git_sources") %}
+
+with issue_merged as (
+    select *
+    from {{ ref('stg_github_issue_merged') }}
+),
+issue as (
+    select *
+    from {{ ref('stg_github_issue') }}
+    where is_pull_request is true
+),
+joined as (
+    select
+        im.commit_sha,
+        im.issue_id,
+        im.merged_at,
+        im.user_id,
+        i.repository_id
+    from issue_merged im 
+    left join issue i
+        on im.issue_id = i.issue_id
+)
+select *
+from joined
+
+{% endif %}

--- a/models/integration/int_github/int_github_pull_request_review.sql
+++ b/models/integration/int_github/int_github_pull_request_review.sql
@@ -1,0 +1,28 @@
+{% if var("dev_warehouse_git_sources") %}
+
+with pr_review as (
+    select *
+    from {{ ref('stg_github_pull_request_review') }}
+),
+commit as (
+    select *
+    from {{ ref('stg_github_commit') }}
+),
+joined as (
+    select
+        prr.review_id,
+        prr.body,
+        prr.commit_sha,
+        prr.pull_request_id,
+        prr.state,
+        prr.submitted_at,
+        prr.user_id,
+        c.repository_id
+    from pr_review prr
+    left join commit c 
+        on prr.commit_sha = c.commit_sha
+)
+select *
+from joined
+
+{% endif %}

--- a/models/integration/int_github/int_github_user.sql
+++ b/models/integration/int_github/int_github_user.sql
@@ -1,0 +1,34 @@
+{% if var("dev_warehouse_git_sources") %}
+
+with user as (
+    select *
+    from {{ ref('stg_github_user') }}
+),
+user_flags as (
+    select *
+    from {{ ref('stg_ra_github_user_flags') }}
+),
+joined as (
+    select
+        u.user_id,
+        u.bio,
+        u.blog,
+        u.company,
+        u.created_at,
+        u.username,
+        u.name,
+        u.type,
+        u.location,
+        u.updated_at,
+        u.is_site_admin,
+        u.is_hireable,
+        uf.is_rittman,
+        uf.is_contractor
+    from user u
+    left join user_flags uf
+        on u.username = uf.github_username
+)
+select *
+from joined
+
+{% endif %}

--- a/models/integration/int_github/schema/schema.yml
+++ b/models/integration/int_github/schema/schema.yml
@@ -1,0 +1,96 @@
+version: 2
+
+models:
+  - name: int_github_commit
+    description: RA github commits
+    columns:
+      - name: commit_sha
+        tests:
+          - unique
+          - not_null
+      - name: repository_id
+        tests:
+          - not_null
+      - name: user_id
+        tests:
+          - not_null
+  - name: int_github_contributions
+    description: Contributions to the RA github by contribution type, repo, user and the time of contribution
+    columns:
+      - name: contribution_type
+        tests:
+          - not_null
+      - name: user_id
+        tests:
+          - not_null
+      - name: repository_id
+        tests:
+          - not_null
+      - name: contributed_at
+        tests:
+          - not_null
+  - name: int_github_pull_request_merged
+    description: RA github PRs that have been merged
+    columns:
+      - name: commit_sha
+        tests:
+          - unique
+          - not_null
+      - name: issue_id
+        tests:
+          - not_null
+      - name: merged_at
+        tests:
+          - not_null
+      - name: user_id
+        tests:
+          - not_null
+      - name: repository_id
+        tests:
+          - not_null
+  - name: int_github_pull_request_review
+    description: RA github PR reviews
+    columns:
+      - name: review_id
+        tests:
+          - not_null
+      - name: commit_id
+        tests:
+          - not_null
+      - name: pull_request_id
+        tests:
+          - not_null
+      - name: user_id
+        tests:
+          - not_null
+      - name: repository_id
+        tests:
+          - not_null
+  - name: int_github_pull_request
+    description: RA github PRs
+    columns:
+      - name: review_id
+        tests:
+          - not_null
+      - name: issue_id
+        tests:
+          - not_null
+      - name: pull_request_id
+        tests:
+          - not_null
+      - name: user_id
+        tests:
+          - not_null
+      - name: repository_id
+        tests:
+          - not_null
+  - name: int_github_user
+    description: RA github users
+    columns:
+      - name: user_id
+        tests:
+          - unique
+          - not_null
+      - name: login
+        tests:
+          - not_null

--- a/models/sources/stg_github/bigquery/fivetran/stg_github_commit.sql
+++ b/models/sources/stg_github/bigquery/fivetran/stg_github_commit.sql
@@ -1,0 +1,28 @@
+{{config(enabled = target.type == 'bigquery')}}
+{% if var("dev_warehouse_git_sources") %}
+{% if 'github' in var("dev_warehouse_git_sources") %}
+{% if var("stg_github_etl") == 'fivetran' %}
+
+with commit as (
+    select *
+    from {{ source('fivetran_github_sources','commit') }}
+),
+renamed as (
+    select
+        cast(sha as string) as commit_sha,
+        cast(author_date as datetime) as author_date,
+        cast(author_email as string) as author_email,
+        cast(author_name as string) as author_name,
+        cast(committer_date as datetime) as committer_date,
+        cast(committer_email as string) as committer_email,
+        cast(committer_name as string) as committer_name,
+        cast(message as string) as message,
+        cast(repository_id as numeric) as repository_id
+    from commit c
+)
+select *
+from renamed
+
+{% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}

--- a/models/sources/stg_github/bigquery/fivetran/stg_github_issue.sql
+++ b/models/sources/stg_github/bigquery/fivetran/stg_github_issue.sql
@@ -1,0 +1,32 @@
+{{config(enabled = target.type == 'bigquery')}}
+{% if var("dev_warehouse_git_sources") %}
+{% if 'github' in var("dev_warehouse_git_sources") %}
+{% if var("stg_github_etl") == 'fivetran' %}
+
+with source as (
+    select *
+    from {{ source('fivetran_github_sources','issue') }}
+),
+renamed as (
+    select
+        cast(id as numeric) as issue_id,
+        cast(milestone_id as numeric) as milestone_id,
+        cast(repository_id as numeric) as repository_id,
+        cast(user_id as numeric) as user_id,
+        cast(body as string) as body,
+        cast(closed_at as datetime) as closed_at,
+        cast(created_at as datetime) as created_at,
+        cast(locked as boolean) as is_locked,
+        cast(number as numeric) as number,
+        cast(state as string) as state,
+        cast(title as string) as title,
+        cast(updated_at as datetime) as updated_at,
+        cast(pull_request as boolean) as is_pull_request
+    from source
+)
+select *
+from renamed
+
+{% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}

--- a/models/sources/stg_github/bigquery/fivetran/stg_github_issue_merged.sql
+++ b/models/sources/stg_github/bigquery/fivetran/stg_github_issue_merged.sql
@@ -1,0 +1,23 @@
+{{config(enabled = target.type == 'bigquery')}}
+{% if var("dev_warehouse_git_sources") %}
+{% if 'github' in var("dev_warehouse_git_sources") %}
+{% if var("stg_github_etl") == 'fivetran' %}
+
+with source as (
+    select *
+    from {{ source('fivetran_github_sources','issue_merged') }}
+),
+renamed as (
+    select
+        cast(commit_sha as string) as commit_sha,
+        cast(issue_id as numeric) as issue_id,
+        cast(merged_at as datetime) as merged_at,
+        cast(actor_id as numeric) as user_id
+    from source
+)
+select *
+from renamed
+
+{% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}

--- a/models/sources/stg_github/bigquery/fivetran/stg_github_pull_request.sql
+++ b/models/sources/stg_github/bigquery/fivetran/stg_github_pull_request.sql
@@ -1,0 +1,33 @@
+{{config(enabled = target.type == 'bigquery')}}
+{% if var("dev_warehouse_git_sources") %}
+{% if 'github' in var("dev_warehouse_git_sources") %}
+{% if var("stg_github_etl") == 'fivetran' %}
+
+with source as (
+    select *
+    from {{ source('fivetran_github_sources','pull_request') }}
+),
+renamed as (
+    select
+        cast(id as numeric) as pull_request_id,
+        cast(base_sha as string) as base_sha,
+        cast(base_repo_id as numeric) as base_repo_id,
+        cast(base_user_id as numeric) as base_user_id,
+        cast(head_sha as string) as head_sha,
+        cast(head_repo_id as numeric) as head_repo_id,
+        cast(head_user_id as numeric) as head_user_id,
+        cast(issue_id as numeric) as issue_id,
+        cast(merge_commit_sha as string) as merge_commit_sha,
+        cast(base_label as string) as base_label,
+        cast(base_ref as string) as base_ref,
+        cast(draft as boolean) as is_draft,
+        cast(head_label as string) as head_label,
+        cast(head_ref as string) as head_ref
+    from source
+)
+select *
+from renamed
+
+{% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}

--- a/models/sources/stg_github/bigquery/fivetran/stg_github_pull_request_review.sql
+++ b/models/sources/stg_github/bigquery/fivetran/stg_github_pull_request_review.sql
@@ -1,0 +1,26 @@
+{{config(enabled = target.type == 'bigquery')}}
+{% if var("dev_warehouse_git_sources") %}
+{% if 'github' in var("dev_warehouse_git_sources") %}
+{% if var("stg_github_etl") == 'fivetran' %}
+
+with source as (
+    select *
+    from {{ source('fivetran_github_sources','pull_request_review') }}
+),
+renamed as (
+    select
+        cast(id as numeric) as review_id,
+        cast(body as string) as body,
+        cast(commit_sha as string) as commit_sha,
+        cast(pull_request_id as numeric) as pull_request_id,
+        cast(lower(state) as string) as state,
+        cast(submitted_at as datetime) as submitted_at,
+        cast(user_id as numeric) as user_id
+    from source 
+)
+select *
+from renamed
+
+{% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}

--- a/models/sources/stg_github/bigquery/fivetran/stg_github_release.sql
+++ b/models/sources/stg_github/bigquery/fivetran/stg_github_release.sql
@@ -1,0 +1,31 @@
+{{config(enabled = target.type == 'bigquery')}}
+{% if var("dev_warehouse_git_sources") %}
+{% if 'github' in var("dev_warehouse_git_sources") %}
+{% if var("stg_github_etl") == 'fivetran' %}
+
+with source as (
+    select *
+    from {{ source('fivetran_github_sources','release') }}
+),
+renamed as (
+    select
+        cast(id as numeric) as release_id,
+        cast(author_id as numeric) as user_id,
+        cast(repository_id as numeric) as repository_id,
+        cast(body as string) as body,
+        cast(created_at as datetime) as created_at,
+        cast(draft as boolean) as is_draft,
+        cast(name as string) as release_name,
+        cast(prerelease as boolean) as is_prerelease,
+        cast(published_at as datetime) as published_at,
+        cast(tag_name as string) as tag_name,
+        cast(target_commitish as string) as target_commitish,
+        cast(updated_at as datetime) as updated_at
+    from source
+)
+select *
+from renamed
+
+{% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}

--- a/models/sources/stg_github/bigquery/fivetran/stg_github_repository.sql
+++ b/models/sources/stg_github/bigquery/fivetran/stg_github_repository.sql
@@ -1,0 +1,31 @@
+{{config(enabled = target.type == 'bigquery')}}
+{% if var("dev_warehouse_git_sources") %}
+{% if 'github' in var("dev_warehouse_git_sources") %}
+{% if var("stg_github_etl") == 'fivetran' %}
+
+with source as (
+    select *
+    from {{ source('fivetran_github_sources','repository') }}
+),
+renamed as (
+    select
+        cast(id as numeric) as repository_id,
+        cast(name as string) as repository_name,
+        cast(owner_id as numeric) as owner_user_id,
+        cast(full_name as string) as full_name,
+        cast(created_at as datetime) as created_at,
+        cast(description as string) as description,
+        cast(default_branch as string) as default_branch,
+        cast(homepage as string) as homepage,
+        cast(language as string) as language,
+        cast(fork as boolean) as is_fork,
+        cast(archived as boolean) as is_archived,
+        cast(private as boolean) as is_private
+    from source
+)
+select *
+from renamed
+
+{% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}

--- a/models/sources/stg_github/bigquery/fivetran/stg_github_user.sql
+++ b/models/sources/stg_github/bigquery/fivetran/stg_github_user.sql
@@ -1,0 +1,31 @@
+{{config(enabled = target.type == 'bigquery')}}
+{% if var("dev_warehouse_git_sources") %}
+{% if 'github' in var("dev_warehouse_git_sources") %}
+{% if var("stg_github_etl") == 'fivetran' %}
+
+with user as (
+    select *
+    from {{ source('fivetran_github_sources','user') }}
+),
+renamed as (
+    select
+        cast(id as numeric) as user_id,
+        cast(bio as string) as bio,
+        cast(blog as string) as blog,
+        cast(company as string) as company,
+        cast(created_at as datetime) as created_at,
+        cast(login as string) as username,
+        cast(name as string) as name,
+        cast(type as string) as type,
+        cast(location as string) as location,
+        cast(updated_at as datetime) as updated_at,
+        cast(site_admin as boolean) as is_site_admin,
+        cast(hireable as boolean) as is_hireable
+    from user u
+)
+select *
+from renamed
+
+{% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}

--- a/models/sources/stg_github/bigquery/fivetran/stg_github_user_email.sql
+++ b/models/sources/stg_github/bigquery/fivetran/stg_github_user_email.sql
@@ -1,0 +1,22 @@
+{{config(enabled = target.type == 'bigquery')}}
+{% if var("dev_warehouse_git_sources") %}
+{% if 'github' in var("dev_warehouse_git_sources") %}
+{% if var("stg_github_etl") == 'fivetran' %}
+
+with source as (
+    select *
+    from {{ source('fivetran_github_sources','user_email') }}
+),
+renamed as (
+    select
+        cast(email as string) as email,
+        cast(user_id as numeric) as user_id,
+        cast(name as string) as name
+    from source
+)
+select *
+from renamed
+
+{% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}

--- a/models/sources/stg_github/bigquery/fivetran/stg_ra_github_user_flags.sql
+++ b/models/sources/stg_github/bigquery/fivetran/stg_ra_github_user_flags.sql
@@ -1,0 +1,22 @@
+{{config(enabled = target.type == 'bigquery')}}
+{% if var("dev_warehouse_git_sources") %}
+{% if 'github' in var("dev_warehouse_git_sources") %}
+{% if var("stg_github_etl") == 'fivetran' %}
+
+with user_flags as (
+    select *
+    from {{ source('stg_dbt_seed','ra_github_user_flags') }}
+),
+renamed as (
+    select
+        cast(github_username as string) as github_username,
+        cast(is_rittman as boolean) as is_rittman,
+        cast(is_contractor as boolean) as is_contractor
+    from user_flags
+)
+select *
+from renamed
+
+{% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}
+{% else %} {{config(enabled=false)}} {% endif %}

--- a/models/sources/stg_github/schema/schema.yml
+++ b/models/sources/stg_github/schema/schema.yml
@@ -1,0 +1,112 @@
+version: 2
+
+models:
+  - name: stg_github_commit
+    description: RA github commits
+    columns:
+      - name: commit_sha
+        tests:
+          - unique
+          - not_null
+      - name: repository_id
+        tests:
+          - not_null
+  - name: stg_github_issue_merged
+    description: RA github issues merged
+    columns:
+      - name: issue_id
+        tests:
+          - unique
+          - not_null
+      - name: commit_sha
+        tests:
+          - not_null
+      - name: user_id
+        tests:
+          - not_null
+  - name: stg_github_issue
+    description: RA github issues
+    columns:
+      - name: issue_id
+        tests:
+          - unique
+          - not_null
+      - name: repository_id
+        tests:
+          - not_null
+      - name: user_id
+        tests:
+          - not_null
+  - name: stg_github_pull_request_review
+    description: RA github PR reviews
+    columns:
+      - name: review_id
+        tests:
+          - unique
+          - not_null
+      - name: commit_sha
+        tests:
+          - not_null
+      - name: pull_request_id
+        tests:
+          - not_null
+      - name: user_id
+        tests:
+          - not_null
+  - name: stg_github_pull_request
+    description: RA github PRs
+    columns:
+      - name: pull_request_id
+        tests:
+          - unique
+          - not_null
+      - name: issue_id
+        tests:
+          - not_null
+  - name: stg_github_release
+    description: RA github releases
+    columns:
+      - name: release_id
+        tests:
+          - unique
+          - not_null
+      - name: repository_id
+        tests:
+          - not_null
+      - name: user_id
+        tests:
+          - not_null
+  - name: stg_github_repository
+    description: RA github repos
+    columns:
+      - name: repository_id
+        tests:
+          - unique
+          - not_null
+  - name: stg_github_user_email
+    description: RA github user emails
+    columns:
+      - name: user_id
+        tests:
+          - unique
+          - not_null
+      - name: email
+        tests:
+          - not_null
+  - name: stg_github_user
+    description: RA github users
+    columns:
+      - name: user_id
+        tests:
+          - unique
+          - not_null
+      - name: login
+        tests:
+          - not_null
+  - name: stg_ra_github_user_flags
+    description: RA github users
+    columns:
+      - name: github_username
+        tests:
+          - unique
+          - not_null

--- a/models/sources/stg_github/schema/sources.yml
+++ b/models/sources/stg_github/schema/sources.yml
@@ -1,0 +1,52 @@
+version: 2
+
+sources:
+  - name: fivetran_github_sources
+    schema: "{{ var('stg_github_fivetran_schema') }}"
+
+    freshness:
+      warn_after: {count: 1, period: day}
+
+    loaded_at_field: _fivetran_synced
+
+    tables:
+      # - name: card
+      # - name: column
+      - name: commit
+      # - name: commit_file
+      # - name: commit_parent
+      - name: commit_pull_request
+      # - name: deployment
+      # - name: deployment_status
+      - name: issue
+      # - name: issue_assignee
+      # - name: issue_comment
+      # - name: issue_label
+      # - name: issue_label_history
+      # - name: issue_locked_history
+      # - name: issue_mention
+      - name: issue_merged
+      # - name: issue_milestone_history
+      # - name: issue_project_history
+      # - name: issue_referenced
+      # - name: issue_renamed
+      # - name: label
+      # - name: milestone
+      # - name: project
+      - name: pull_request
+      - name: pull_request_review
+      # - name: pull_request_review_dismissed
+      - name: release
+      # - name: repo_team
+      - name: repository
+      # - name: requested_reviewer_history
+      # - name: team
+      # - name: team_membership
+      - name: user
+      - name: user_email
+
+  - name: stg_dbt_seed
+    schema: dbt_seed
+
+    tables:
+      - name: ra_github_user_flags

--- a/models/warehouse/w_dev/wh_github/wh_github_contributions_fact.sql
+++ b/models/warehouse/w_dev/wh_github/wh_github_contributions_fact.sql
@@ -1,0 +1,18 @@
+{% if var("dev_warehouse_git_sources") %}
+
+with contributions as (
+    select *
+    from {{ ref('int_github_contributions') }}
+),
+final as (
+    select
+        contribution_type,
+        user_id,
+        repository_id,
+        contributed_at
+    from contributions 
+)
+select *
+from final
+
+{% endif %}

--- a/models/warehouse/w_dev/wh_github/wh_github_repositories_dim.sql
+++ b/models/warehouse/w_dev/wh_github/wh_github_repositories_dim.sql
@@ -1,0 +1,24 @@
+{% if var("dev_warehouse_git_sources") %}
+
+with repos as (
+    select *
+    from {{ ref('stg_github_repository') }}
+),
+final as (
+    select
+        repository_id,
+        repository_name,
+        owner_user_id,
+        full_name,
+        created_at,
+        description,
+        default_branch,
+        is_fork,
+        is_archived,
+        is_private
+    from repos 
+)
+select *
+from final
+
+{% endif %}

--- a/models/warehouse/w_dev/wh_github/wh_github_users_dim.sql
+++ b/models/warehouse/w_dev/wh_github/wh_github_users_dim.sql
@@ -1,0 +1,22 @@
+{% if var("dev_warehouse_git_sources") %}
+
+with users as (
+    select *
+    from {{ ref('int_github_user') }}
+),
+final as (
+    select
+        user_id,
+        company,
+        created_at,
+        username,
+        name,
+        type,
+        is_rittman,
+        is_contractor
+    from users 
+)
+select *
+from final
+
+{% endif %}


### PR DESCRIPTION
<!---
Provide a short summary in the Title above. Examples of good PR titles:
* "Feature: add so-and-so models"
* "Fix: deduplicate such-and-such"
* "Update: dbt version 0.13.0"
-->

## Description & motivation
Using the data from the Fivetran GitHub integration, create a set of models to allow us to answer the following questions:

1. Which customer has the most code-base contributions by RA team members [commits, pr's, releases]
2. What’s the average PR revision rate [how many re-approval requests]
3. How long do PR’s take to get closed and merged
4. Which customer is most enabled [contributes the most themselves]
    - Which customer enabled the fastest?
        - Can we make a target out of this?
        - Has it been improving overtime or getting worse

## Changes to ERD
![image](https://user-images.githubusercontent.com/93135126/140917594-35ab95bb-0a5f-491b-9eb7-8806c6e0ecfa.png)

## Changes to DAG
![image](https://user-images.githubusercontent.com/93135126/140918442-9474b48a-b488-482f-b97d-b1be88818ff5.png)


## Checklist:
<!-- 
This is for you as a developer. Have you done all the following tasks before submitting this PR?

-->
- [ ] My pull request represents one story (logical piece of work).
- [ ] My SQL follows the RA style guide
- [ ] I have materialized my models appropriately.
- [ ] I have added appropriate tests and documentation to any new models.
- [ ] I ran the dbt package in my development environment without error.
- [ ] I ran the dbt test suite in my development environment without error.
- [ ] My dbt package has no residual models that are no longer used.

## Additional comments:

This is a draft pull request as there are still some parts to complete and things I'd like to discuss:
- I haven’t created surrogate / labelled natural & foreign keys yet
- I'd like to get your thoughts on the shape of the warehouse layer
- ~22% of contributions are missing a `user_id`. A vast majority of this is due to the method for getting the `user_id` for commits. According to the [GitHub ERD](https://docs.google.com/presentation/d/1lx6ez7-x-s-n2JCnCi3SjG4XMmx9ysNUvaNCaWc3I_I/edit#slide=id.g244d368397_0_1), the `user_email` table needs to be used to join `commits` to `users` (either the `author_email` or `commiter_email` - the latter gives a marginally higher hit rate), but many of these emails don't have a corresponding record in the `user_email` table.
- I haven't tested & documented the warehouse layer as I'd expect changes based on our conversations on the above.
- Where would I find the RA style guide?
